### PR TITLE
Fixed exports default

### DIFF
--- a/src/commands/api/genius.ts
+++ b/src/commands/api/genius.ts
@@ -62,4 +62,4 @@ const CovidCommand: Command = {
 	},
 };
 
-export default CovidCommand;
+export default GeniusCommand;


### PR DESCRIPTION
Exports default was not constant with other commands as it was using CovidCommand and not what it was supposed to be GeniusCommand